### PR TITLE
Add dotenv to pip requirements

### DIFF
--- a/agentic_rag_with_unify/notebook/Unify_Qdrant_Agentic_RAG.ipynb
+++ b/agentic_rag_with_unify/notebook/Unify_Qdrant_Agentic_RAG.ipynb
@@ -39,7 +39,7 @@
    },
    "outputs": [],
    "source": [
-    "#!pip install qdrant-client fastembed unifyai python-dotenv pandas numpy==1.26.4"
+    "#!pip install qdrant-client fastembed unifyai python-dotenv pandas numpy==1.26.4 dotenv"
    ]
   },
   {


### PR DESCRIPTION
If I don't have this,  the code`from dotenv import load_dotenv` fails.